### PR TITLE
452: "set field" to use non-greedy regexp

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -82,7 +82,7 @@ module.exports.actions = [
 	// E.g. "set field #username to example"
 	{
 		name: 'set-field-value',
-		match: /^set( field)? (.+) to (.+)$/i,
+		match: /^set( field)? (.+?) to (.+)$/i,
 		run: async (browser, page, options, matches) => {
 			const selector = matches[2];
 			const value = matches[3];

--- a/test/unit/lib/action.test.js
+++ b/test/unit/lib/action.test.js
@@ -328,6 +328,12 @@ describe('lib/action', () => {
 					'.foo .bar .baz',
 					'hello world'
 				]);
+				assert.deepEqual('set field .foo to hello to the world'.match(action.match), [
+					'set field .foo to hello to the world',
+					' field',
+					'.foo',
+					'hello to the world'
+				]);
 			});
 
 		});


### PR DESCRIPTION
Current matcher for "set field" uses a greedy regular expression which will continue matching a selector all the way up to the last occurrence of `" to "`.  However, this might occur within a value (the final desired capture group) and the matches will be performed incorrectly.

Using the non-greedy `.+?` will instead attempt to find the shortest match which satisfies the overall expression.  

There is a small(er) risk that a desired selector contains a custom element named 'to' but I deem this to be far less likely than wanting ` to ` appearing in a desired input value.